### PR TITLE
Use shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ],
-  "packageRules": [
-    {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    }
+    "github>compscidr/renovate-config:android"
   ]
 }


### PR DESCRIPTION
Part of a sweep moving all Kotlin/Java repos onto the shared [compscidr/renovate-config](https://github.com/compscidr/renovate-config) presets, so the automerge policy and the JUnit/compileSdk reasoning live in one place instead of being copy-pasted per repo.

Uses `:android`, which adds `compileSdk` tracking against the latest released Android API level. Not `:android-junit5` — that preset holds `junit-bom` below 6 for the `de.mannodermaus.junit5` instrumented-test runner, which this repo does not use.

Any repo-specific settings already here were carried over unchanged.

The `compileSdk` manager exists because androidx releases periodically start requiring a newer `compileSdk`, which fails `checkAarMetadata` on every open Renovate PR at once with an error that reads like a `minSdk` problem. It is not — `minSdk` and `targetSdk` are deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)